### PR TITLE
fixes error when convert_streams_to_rms() is used on a single stream

### DIFF
--- a/R/convert-streams-to-rms.R
+++ b/R/convert-streams-to-rms.R
@@ -2,6 +2,18 @@ get_parent_blk_rm <- function(x, y, gap) {
   y <- y |>
     dplyr::anti_join(as_tibble(x), by = "blk")
 
+  if (nrow(y) == 0) {
+    return(
+      x |>
+        as_tibble() |>
+        dplyr::mutate(
+          parent_blk = NA_integer_,
+          parent_rm = NA_real_
+        ) |>
+        dplyr::select("blk", "parent_blk", "parent_rm")
+    )
+  }
+
   x <- x |>
     dplyr::mutate(
       parent_blk = sf::st_nearest_feature(x, y),

--- a/tests/testthat/test-convert-streams-to-rms.R
+++ b/tests/testthat/test-convert-streams-to-rms.R
@@ -1,3 +1,20 @@
+test_that("fwa_convert_streams_to_rms works with a single stream (no parent)", {
+  linestring <- sf::st_linestring(
+    matrix(c(0, 0, 0, 100, 0, 200), ncol = 2, byrow = TRUE)
+  )
+  streams <- sf::st_sf(
+    blk = 1L,
+    geometry = sf::st_sfc(linestring, crs = 3005)
+  )
+  x <- fwa_convert_streams_to_rms(streams, interval = 50)
+  expect_s3_class(x, "sf")
+  expect_identical(nrow(x), 5L)
+  expect_s3_class(x$geometry, "sfc_POINT")
+  expect_identical(x$rm, c(0L, 50L, 100L, 150L, 200L))
+  expect_true(all(is.na(x$parent_blk)))
+  expect_true(all(is.na(x$parent_rm)))
+})
+
 test_that("fwa_convert_streams_to_rms", {
   watershed <- fwa_add_watershed_to_blk(data.frame(blk = 356308001, rm = 1000))
   network <- fwa_add_collection_to_polygon(watershed)


### PR DESCRIPTION
function assumed every stream has at least 1 other stream that could be its parent. A lone stream has no possible parent. This allows for a single stream to be input. 